### PR TITLE
Install libudev-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mobiledevops/flutter-sdk-image:3.16.4
 USER root
 RUN apt -qq update
 RUN apt -qqy --no-install-recommends install cmake
-RUN apt -y install ninja-build clang libgtk-3-dev
+RUN apt -y install ninja-build clang libgtk-3-dev libudev-dev
 
 # use newer rust version
 RUN apt -y remove cargo


### PR DESCRIPTION
Reason/Description: Required because paraguide visualizer uses the serialport

