### PR TITLE
Add libasound2-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt -qq update
 RUN apt -qqy --no-install-recommends install cmake
 RUN apt -y install ninja-build clang libgtk-3-dev
 RUN apt -y install libudev-dev # serial usb
-RUN apt -y install alsa-base alsa-utils # sound
+RUN apt -y install alsa-base alsa-utils libasound2-dev # sound
 
 # use newer rust version
 RUN apt -y remove cargo


### PR DESCRIPTION
Reason/Description: It is required by the alsa-sys rust crate

