### PR TITLE
Add libsdl2-dev for simulated display support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt -qqy --no-install-recommends install cmake
 RUN apt -y install ninja-build clang libgtk-3-dev
 RUN apt -y install libudev-dev # serial usb
 RUN apt -y install alsa-base alsa-utils libasound2-dev # sound
+RUN apt -y install libsdl2-dev # display simulator
 
 # use newer rust version
 RUN apt -y remove cargo

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,13 @@ USER mobiledevops
 #RUN sdkmanager --sdk_root=$ANDROID_HOME "ndk;26.1.10909125"
 ENV ANDROID_NDK $ANDROID_HOME/ndk
 
+# Required for Flutter Rust Bridge
+RUN mkdir -p $HOME/.gradle
+RUN echo "ANDROID_NDK=$ANDROID_NDK" > $HOME/.gradle/gradle.properties
+
 # Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH ~/.cargo/bin:$PATH
+ENV PATH $HOME/.cargo/bin:$PATH
 # nightly is required to use const generic expressions
 RUN rustup default nightly-2024-10-01
 RUN rustup override set nightly-2024-10-01

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,15 +17,13 @@ RUN apt -y install libsdl2-dev # display simulator
 RUN apt -y remove cargo
 RUN apt -y autoremove
 
-USER mobiledevops
-
 # ANDROID NDK
 #RUN sdkmanager --sdk_root=$ANDROID_HOME "ndk;26.1.10909125"
 ENV ANDROID_NDK $ANDROID_HOME/ndk
 
 # Required for Flutter Rust Bridge
-RUN mkdir -p $HOME/.gradle
-RUN echo "ANDROID_NDK=$ANDROID_NDK" > $HOME/.gradle/gradle.properties
+#RUN mkdir -p $HOME/.gradle
+#RUN echo "ANDROID_NDK=$ANDROID_NDK" > $HOME/.gradle/gradle.properties
 
 # Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mobiledevops/flutter-sdk-image:3.16.4
+FROM mobiledevops/flutter-sdk-image:3.19.4
 
 USER root
 RUN apt -qq update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mobiledevops/flutter-sdk-image:3.19.4
+FROM mobiledevops/android-sdk-image:34.0.1
 
 USER root
 RUN apt -qq update
@@ -16,8 +16,6 @@ USER mobiledevops
 
 # ANDROID NKD
 #RUN sdkmanager --sdk_root=$ANDROID_HOME "ndk;26.1.10909125"
-# https://github.com/bbqsrc/cargo-ndk/issues/77
-RUN sdkmanager --sdk_root=$ANDROID_HOME "ndk;23.2.8568313"
 ENV ANDROID_NDK $ANDROID_HOME/ndk
 
 # Required for Flutter Rust Bridge

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM mobiledevops/android-sdk-image:34.0.1
 
 USER root
+
+# workaround for https://github.com/microsoft/WSL/discussions/11097
+RUN mv /usr/sbin/telinit /usr/sbin/telinit.bak2
+RUN ln -s /usr/bin/true /usr/sbin/telinit
+
 RUN apt -qq update
 RUN apt -qqy --no-install-recommends install cmake
 RUN apt -y install ninja-build clang libgtk-3-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,9 @@ RUN apt -y autoremove
 
 USER mobiledevops
 
-# ANDROID NKD
+# ANDROID NDK
 #RUN sdkmanager --sdk_root=$ANDROID_HOME "ndk;26.1.10909125"
 ENV ANDROID_NDK $ANDROID_HOME/ndk
-
-# Required for Flutter Rust Bridge
-RUN mkdir -p ~/.gradle
-RUN echo "ANDROID_NDK=$ANDROID_NDK" > ~/.gradle/gradle.properties
 
 # Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,12 @@ RUN apt -y install libsdl2-dev # display simulator
 RUN apt -y remove cargo
 RUN apt -y autoremove
 
+# $HOME ddefined in mobiledevops/android-sdk-image
+
 # ANDROID NDK
-#RUN sdkmanager --sdk_root=$ANDROID_HOME "ndk;26.1.10909125"
+# RUN sdkmanager --sdk_root=$ANDROID_HOME "ndk;26.1.10909125"
+# https://github.com/bbqsrc/cargo-ndk/issues/77
+RUN sdkmanager --sdk_root=$ANDROID_HOME "ndk;23.2.8568313"
 ENV ANDROID_NDK $ANDROID_HOME/ndk
 
 # Required for Flutter Rust Bridge

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,17 +17,17 @@ RUN apt -y install libsdl2-dev # display simulator
 RUN apt -y remove cargo
 RUN apt -y autoremove
 
-# $HOME ddefined in mobiledevops/android-sdk-image
+# $HOME defined in mobiledevops/android-sdk-image
 
 # ANDROID NDK
-# RUN sdkmanager --sdk_root=$ANDROID_HOME "ndk;26.1.10909125"
+#RUN sdkmanager --sdk_root=$ANDROID_HOME "ndk;26.1.10909125"
 # https://github.com/bbqsrc/cargo-ndk/issues/77
 RUN sdkmanager --sdk_root=$ANDROID_HOME "ndk;23.2.8568313"
 ENV ANDROID_NDK $ANDROID_HOME/ndk
 
 # Required for Flutter Rust Bridge
-#RUN mkdir -p $HOME/.gradle
-#RUN echo "ANDROID_NDK=$ANDROID_NDK" > $HOME/.gradle/gradle.properties
+RUN mkdir -p $HOME/.gradle
+RUN echo "ANDROID_NDK=$ANDROID_NDK" > $HOME/.gradle/gradle.properties
 
 # Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
1) Adding libsdl2-dev lib
2) Update docker base image
Reason: Fixes
 1.095 E: The repository 'http://archive.ubuntu.com/ubuntu mantic Release' does not have a Release file.
1.095 E: The repository 'http://archive.ubuntu.com/ubuntu mantic-updates Release' does not have a Release file.
1.095 E: The repository 'http://archive.ubuntu.com/ubuntu mantic-backports Release' does not have a Release file.
1.095 E: The repository 'http://security.ubuntu.com/ubuntu mantic-security Release' does not have a Release file.


3) Fixing another issue:
** workaround for https://github.com/microsoft/WSL/discussions/11097**
RUN mv /usr/sbin/telinit /usr/sbin/telinit.bak2
RUN ln -s /usr/bin/true /usr/sbin/telinit
